### PR TITLE
VSAT-3796: document conversation message attachment object

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+**2026-06-10**
+- Documented the [attachment object](#attachment-object) fields on conversation messages. Note that for **private** attachments (`isPublic` = 0) the `url` is a temporary link that expires **7 days** after it is generated.
+
 **2026-05-18**
 - Added `updatedOn` to the supported `sortOrder` values of [Retrieve a reservations list](#retrieve-a-reservations-list). Use it to sort reservations ascending by last modification time (oldest first). The default ordering (no `sortOrder`) remains descending by `updatedOn`.
 

--- a/source/includes/_conversation_conversationMessageObject.md
+++ b/source/includes/_conversation_conversationMessageObject.md
@@ -68,6 +68,30 @@ Property | Required | Type                       | Description
 `communicationAlwaysTrigger` | no | int                        | 1 or 0
 `date` | no | date (YYYY-MM-DD HH:MM:SS) | the message scheduled date
 `sentChannelDate` | no | date (YYYY-MM-DD HH:MM:SS) | the message send to channel date
-`attachments` | no | array                      | attachments of this message
+`attachments` | no | array                      | attachments of this message. Each item is an [attachment object](#attachment-object).
 `insertedOn` | no | date (YYYY-MM-DD HH:MM:SS) | the message inserted on
 `updatedOn` | no | date (YYYY-MM-DD HH:MM:SS) | the message updated on
+
+### Attachment object
+
+Each item in the `attachments` array describes a single file attached to the message.
+
+Property | Type | Description
+-------- | ---- | -----------
+`id` | int | Identifier of the attachment
+`accountId` | int | Identifier of account
+`listingMapId` | int | Identifier of listing object
+`reservationId` | int | Identifier of reservation object
+`taskId` | int | Identifier of task object, if the attachment belongs to a task
+`conversationMessageId` | int | Identifier of the conversation message the attachment belongs to
+`communicationId` | int | Identifier of communication
+`name` | string | Original file name
+`url` | string | Download URL for the file. For private attachments (`isPublic` = 0) this is a temporary link — see the TTL note below.
+`extension` | string | File extension (e.g. `jpeg`)
+`mimeType` | string | MIME type of the file (e.g. `image/jpeg`)
+`isImage` | bool | Whether the attachment is an image
+`isPublic` | bool | Whether the attachment is publicly accessible. `0` means the attachment is private.
+
+<aside class="warning">
+For <strong>private</strong> attachments (<code>isPublic</code> = 0), the <code>url</code> field is a temporary link that expires <strong>7 days</strong> after it is generated. Do not store the URL itself for long-term use — once it expires you must re-fetch the message (or its conversation) to obtain a freshly generated URL. If you need to keep the file, download it from the URL and store the file on your side before it expires.
+</aside>


### PR DESCRIPTION
## Summary

- Document the `attachment` object fields on conversation messages (`id`, `accountId`, `listingMapId`, `reservationId`, `taskId`, `conversationMessageId`, `communicationId`, `name`, `url`, `extension`, `mimeType`, `isImage`, `isPublic`) in `_conversation_conversationMessageObject.md`, and link the `attachments` array to it.
- Add a warning that for **private** attachments (`isPublic` = 0) the `url` is a temporary link that expires **7 days** after generation; download/store the file before expiry or re-fetch the message for a fresh URL.
- Add a dated changelog entry (2026-06-10) pointing to the new attachment object section.

## Test plan

- [ ] `make up` and confirm the **Attachment object** table and warning render correctly under the conversation message section at http://localhost:4567
- [ ] Verify the changelog entry links to `#attachment-object`
- [ ] Confirm right-hand nav anchor `#attachment-object` resolves