### PR TITLE
CD-108: document Booking.com no-show fields on reservation object

### DIFF
--- a/source/includes/_reservation_reservationObject.md
+++ b/source/includes/_reservation_reservationObject.md
@@ -135,6 +135,8 @@
     "bookingcomIsGeniusMember": 1,
     "bookingcomBookerName": "Marco Rossi",
     "bookingcomBookerCompany": "Acme Travel Agency",
+    "bookingcomNoShowReportedAt": "2026-07-03 14:22:07",
+    "bookingcomNoShowFeeWaived": false,
     "customFieldValues": [
         {
             "customFieldId": 167,
@@ -301,3 +303,5 @@
 | `bookingcomIsGeniusMember`              | no       | int      | `1` if the booker is a Booking.com Genius member, `0` otherwise, `null` for non-Booking.com. Returned by [Retrieve a reservation](#retrieve-a-reservation) only when `includeResources=1` is passed.                                                    |
 | `bookingcomBookerName`                  | no       | string   | Full name of the person who placed the Booking.com reservation. May differ from the guest when booking on behalf of someone else. Returned by [Retrieve a reservation](#retrieve-a-reservation) only when `includeResources=1` is passed.               |
 | `bookingcomBookerCompany`               | no       | string   | Company or travel agency name from the Booking.com booker's affiliations, when the reservation was made on behalf of a business. Returned by [Retrieve a reservation](#retrieve-a-reservation) only when `includeResources=1` is passed.                |
+| `bookingcomNoShowReportedAt`            | no       | datetime | Timestamp a Booking.com no-show was reported for this reservation, format `Y-m-d H:i:s` in the account timezone. `null` when no no-show has been reported. Returned by [Retrieve a reservation](#retrieve-a-reservation) only when `includeResources=1` is passed. |
+| `bookingcomNoShowFeeWaived`             | no       | bool     | Whether the reported Booking.com no-show fee was waived (`true`) or charged (`false`). `null` when no no-show has been reported. Returned by [Retrieve a reservation](#retrieve-a-reservation) only when `includeResources=1` is passed. |


### PR DESCRIPTION
Documents the two fields CD-94 added to the public API reservation resource:

- `bookingcomNoShowReportedAt` (datetime) - when a Booking.com no-show was reported
- `bookingcomNoShowFeeWaived` (bool) - whether the no-show fee was waived or charged

Both are added to the reservation object JSON example and the field table. Like the other `bookingcom*` fields, they are only returned when `includeResources=1` is passed, and are `null` when no no-show has been reported.

Scope note: this covers the REST reservation resource only. CD-94 also made the `reservation.updated` webhook fire on no-show, but the webhook payload does not carry these two fields, so that is intentionally out of scope here.

Jira: CD-108
Source: https://github.com/Hostaway/hostaways ReservationPublicApiController / PublicApiReservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)