### PR TITLE
CD-109: Correct cancellationPolicyDetails shape in reservation docs

### DIFF
--- a/source/includes/_reservation_reservationObject.md
+++ b/source/includes/_reservation_reservationObject.md
@@ -106,20 +106,16 @@
     "vrboCancellationPolicy": null,
     "marriottCancellationPolicy": null,
     "cancellationPolicyDetails": {
-        "id": 2,
-        "accountId": 1,
         "name": "Moderate",
         "channelId": 2001,
         "channelSpecificCode": "moderate",
         "longTerm": false,
         "cancellationPolicyItem": [
             {
-                "id": "1",
-                "cancellationPolicyId": "2",
-                "refundAmount": "100",
+                "refundAmount": 100,
                 "refundType": "percentage",
                 "refundField": "totalPrice",
-                "timeDelta": "-1209600",
+                "timeDelta": -1209600,
                 "event": "arrival"
             }
         ]
@@ -296,7 +292,7 @@
 | `bookingCancellationPolicy`             | no       | string   | Booking.com channel-specific cancellation policy code (e.g. `"13"`), stored as the raw code returned by Booking.com. Populated only for Booking.com reservations; `null` otherwise. Returned only when `includeCancellationPolicy=1` is passed; always included on [Retrieve a reservation](#retrieve-a-reservation) and on create/update/cancel responses. |
 | `vrboCancellationPolicy`                | no       | string   | Vrbo channel-specific cancellation policy code. Populated only for Vrbo reservations; `null` otherwise. Returned only when `includeCancellationPolicy=1` is passed; always included on [Retrieve a reservation](#retrieve-a-reservation) and on create/update/cancel responses. |
 | `marriottCancellationPolicy`            | no       | string   | Marriott channel-specific cancellation policy code. Populated only for Marriott reservations; `null` otherwise. Returned only when `includeCancellationPolicy=1` is passed; always included on [Retrieve a reservation](#retrieve-a-reservation) and on create/update/cancel responses. |
-| `cancellationPolicyDetails`             | no       | object   | The authoritative, immutable cancellation policy captured at booking time — the terms the guest actually booked under, unaffected by later edits to the listing's policy. Same shape as the [Cancellation policy object](#cancellation-policy-object) (`id`, `accountId`, `name`, `cancellationPolicyItem[]`) plus `channelId`, `channelSpecificCode` and `longTerm`. `null` for reservations with no snapshot (e.g. legacy bookings, or channels where the policy was not synced at booking time). Returned only when `includeCancellationPolicy=1` is passed; always included on [Retrieve a reservation](#retrieve-a-reservation) and on create/update/cancel responses. |
+| `cancellationPolicyDetails`             | no       | object   | The authoritative, immutable cancellation policy captured at booking time — the terms the guest actually booked under, unaffected by later edits to the listing's policy. An object with `name`, `channelId`, `channelSpecificCode`, `longTerm` and `cancellationPolicyItem[]` (each item: `refundAmount`, `refundType`, `refundField`, `timeDelta`, `event`). `null` for reservations with no snapshot (e.g. legacy bookings, or channels where the policy was not synced at booking time). Returned only when `includeCancellationPolicy=1` is passed; always included on [Retrieve a reservation](#retrieve-a-reservation) and on create/update/cancel responses. |
 | `hostProxyEmail`                        | no       | string   | Proxy email of the host of the reservation. Will be accessible by including the `includeResources=1` to the [Retrieve a reservations list](#retrieve-a-reservations-list) endpoint or from [Retrieve a reservation](#retrieve-a-reservation) by default |
 | `bookingcomSpecialRequests`             | no       | object   | Booking.com special requests payload (e.g. `remarks`, `geniusFreebies`). See Booking.com's [OTA ResNotif spec](https://developers.booking.com/connectivity/docs/ota-resnotif/) for the upstream `reservation_extra_info` structure. Returned by [Retrieve a reservation](#retrieve-a-reservation) only when `includeResources=1` is passed. `null` for non-Booking.com reservations. |
 | `bookingcomSmokingPreference`           | no       | int      | Booking.com guest smoking preference. `1` = smoking, `0` = non-smoking, `null` if unknown or non-Booking.com. Returned by [Retrieve a reservation](#retrieve-a-reservation) only when `includeResources=1` is passed.                                   |


### PR DESCRIPTION
## What

Aligns the documented `cancellationPolicyDetails` shape (reservation object) with what the public API actually returns after [CD-109](https://hostaway.atlassian.net/browse/CD-109).

The docs described the fat listing-policy shape - top-level `id`/`accountId`, per-item `id`/`cancellationPolicyId`, and string `refundAmount`/`timeDelta`. That was never accurate for reservation-specific snapshots (which have no such ids), and CD-109 now normalises **every** reservation's snapshot to the lean shape, so those internal fields are no longer returned.

## Changes (`_reservation_reservationObject.md`)

- Example: drop `id`, `accountId` (object) and `id`, `cancellationPolicyId` (item); `refundAmount`/`timeDelta` are integers, not strings.
- Field description: replace "same shape as the Cancellation policy object (`id`, `accountId`, …)" with the actual lean shape - `name`, `channelId`, `channelSpecificCode`, `longTerm`, `cancellationPolicyItem[]` (each item: `refundAmount`, `refundType`, `refundField`, `timeDelta`, `event`).

## Note for reviewers

This removes fields (`id`, `accountId`, `cancellationPolicyId`) that the docs previously promised. They were internal DB identifiers, inconsistently delivered (present only on listing-default snapshots, absent on reservation-specific ones), and a consumer (Arbio) flagged them. The listing-policy linkage remains available via the reservation's own top-level `cancellationPolicyId` field. Worth a changelog/release-note line in case any other consumer read them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CD-109]: https://hostaway.atlassian.net/browse/CD-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ